### PR TITLE
Harden GitHub Actions workflows against token disclosure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @SRWieZ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-php.yml
+++ b/.github/workflows/build-php.yml
@@ -1,8 +1,6 @@
 name: Build PHP
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
 #  schedule:
@@ -24,13 +22,15 @@ on:
         default: all
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SPC_VERSION: 2.7.7
 
 jobs:
   build:
     name: ${{ matrix.version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      pull-requests: write
 
     strategy:
       fail-fast: false
@@ -61,7 +61,9 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set SPC binary name
         shell: bash
@@ -142,7 +144,7 @@ jobs:
         run: echo "SPC_BUILD_OS=linux" >> $GITHUB_ENV
 
       - name: Setup system PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
         with:
           php-version: 8.3
           tools: pecl, composer
@@ -185,7 +187,7 @@ jobs:
 
       # Cache downloaded source
       - id: cache-spc-downloads
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ../static-php-cli/downloads
           key: spc-downloads-${{ env.PHP_EXT_HASH }}
@@ -239,7 +241,7 @@ jobs:
           cp ../static-php-cli/buildroot/build-libraries.json build-meta/build-libraries-${{ env.SPC_BUILD_OS }}.json
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
         with:
           branch: update-php-${{ env.PHP_VERSION }}-${{ env.SPC_BUILD_OS }}-${{ env.SPC_BUILD_ARCH }}
           title: "Update PHP ${{ env.PHP_VERSION }} build for ${{ env.SPC_BUILD_OS }} ${{ env.SPC_BUILD_ARCH }}"

--- a/.github/workflows/update-ca-file.yml
+++ b/.github/workflows/update-ca-file.yml
@@ -6,15 +6,19 @@ on:
     - cron:  '0 0 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   fetch-ca-file:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        # Credentials must persist so the inline `git push` below can authenticate.
+        persist-credentials: true
 
     - name: Fetch the latest CA file
       run: |
@@ -46,6 +50,8 @@ jobs:
     needs: fetch-ca-file
     if: needs.fetch-ca-file.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Get the latest release
         id: latestrelease
@@ -63,11 +69,9 @@ jobs:
 
       - name: Create a new release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.1
         with:
           tag_name: v${{ env.VERSION }}
-          release_name: v${{ env.VERSION }}
+          name: v${{ env.VERSION }}
           draft: true
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hardens CI in response to [Composer CVE-2026-45793](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2). Same pattern as [knotsphp/publicip#6](https://github.com/knotsphp/publicip/pull/6).

- Pin every action to a commit SHA (with version comment), including `peter-evans/create-pull-request` (new pin)
- Top-level `permissions: {}` (deny-all) on both workflows; least-privilege per job
- `build-php.yml`: drop the top-level `env: GITHUB_TOKEN` block — it was over-broad (exposed the token to every step including the downloaded `spc` binary). `peter-evans/create-pull-request` still picks up `GITHUB_TOKEN` via its `token` input default
- `update-ca-file.yml`: replace deprecated and archived `actions/create-release@v1` with SHA-pinned `softprops/action-gh-release`
- `persist-credentials: false` on `build-php.yml` checkout; `persist-credentials: true` on `update-ca-file.yml` checkout (explicit, with rationale comment) because the workflow runs `git push` inline to commit the CA refresh
- Add `.github/dependabot.yml` (monthly, grouped, labelled)
- Add `.github/CODEOWNERS`

### Pre-existing bugs not fixed in this PR

The `release` job in `update-ca-file.yml` has two logic bugs that pre-date this PR — flagging them so they don't get lost:

1. `if: needs.fetch-ca-file.outputs.changed == 'true'` references an output that's never declared. `fetch-ca-file` writes `CHANGED` to `$GITHUB_ENV` (env var for later steps in the same job), not to `$GITHUB_OUTPUT`, and has no job-level `outputs:` block. The conditional is always false, so this job has never run.
2. The `Get the latest release` step assigns `LATEST_VERSION` to a bash local variable, then the next step references `${{ steps.latestrelease.outputs.version }}` which is never set.

Together those mean the CA-file auto-release has been silently broken. Worth a separate PR if you want it actually firing.