### PR TITLE
Fix CA-file auto-release job

### DIFF
--- a/.github/workflows/update-ca-file.yml
+++ b/.github/workflows/update-ca-file.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      changed: ${{ steps.cafile.outputs.changed }}
     steps:
     - name: Check out repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,23 +30,20 @@ jobs:
     - name: Check if the CA file has changed
       id: cafile
       run: |
-        CHANGED=$(git diff --name-only | grep cacert.pem || true)
-        if [[ ! -z "$CHANGED" ]]; then
-          echo "CHANGED=true" >> $GITHUB_ENV
+        if git diff --name-only | grep -q '^cacert\.pem$'; then
+          echo "changed=true" >> $GITHUB_OUTPUT
         else
-          echo "CHANGED=false" >> $GITHUB_ENV
+          echo "changed=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Commit changes
-      if: env.CHANGED == 'true'
+      if: steps.cafile.outputs.changed == 'true'
       run: |
         git config --local user.email "srwiez@gmail.com"
         git config --local user.name "SRWieZ"
         git add cacert.pem
         git commit -m "Update CA file"
         git push
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     needs: fetch-ca-file
@@ -57,7 +56,10 @@ jobs:
         id: latestrelease
         run: |
           LATEST_VERSION=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
-          | jq -r .tag_name)
+            | jq -r .tag_name)
+          # Strip leading 'v' so the bumper below produces a clean semver.
+          LATEST_VERSION=${LATEST_VERSION#v}
+          echo "version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes two pre-existing bugs that have prevented the `release` job in `update-ca-file.yml` from ever firing. Flagged in [#159](https://github.com/SRWieZ/php-bin-with-grpc/pull/159).

- `fetch-ca-file` had no job-level `outputs:` block and wrote `CHANGED` to `$GITHUB_ENV`. The release job's `if: needs.fetch-ca-file.outputs.changed == 'true'` was always false. Added `outputs:` and switched to `$GITHUB_OUTPUT`.
- `Get the latest release` assigned `LATEST_VERSION` to a bash local — `${{ steps.latestrelease.outputs.version }}` was empty. Switched to `$GITHUB_OUTPUT` and strip the leading `v` so the awk-bumper produces clean semver.

Drive-by: tightened the cafile grep to `^cacert\.pem$`, removed dead `GITHUB_TOKEN` env on the `Commit changes` step (the inline `git push` uses persisted creds).

> Based on `harden-workflows` (#159) so the file picks up the SHA pins and least-privilege perms. Merge that one first; this PR will then rebase to a clean fix-only diff.